### PR TITLE
JSON Feed Support

### DIFF
--- a/deefuzzer/station.py
+++ b/deefuzzer/station.py
@@ -45,6 +45,7 @@ import random
 import shout
 import urllib
 import mimetypes
+import json
 
 from threading import Thread
 from player import *
@@ -73,8 +74,10 @@ class Station(Thread):
     run_mode = 1
     station_dir = None
     appendtype = 1
-    feed_json = 0
-    feed_rss = 1
+    feeds_json = 0
+    feeds_rss = 1
+    feeds_mode = 1
+    feeds_playlist = 1
 
     def __init__(self, station, q, logger, m3u):
         Thread.__init__(self)
@@ -153,34 +156,29 @@ class Station(Thread):
         self.channel_url = self.server_url + self.channel.mount
 
         # RSS
-        rss_options = {}
-        if 'feed' in self.station:
-            rss_options['rss'] = self.station['feed']
-        elif 'rss' in self.station:
-            rss_options['rss'] = self.station['rss']
+        if 'feeds' in self.station:
+            self.station['rss'] = self.station['feeds']
 
-        self.rss_media_url = self.channel.url + '/media/'
+        if 'rss' in self.station:
+            if 'mode' in self.station['rss']:
+                self.feeds_mode = int(self.station['rss']['mode'])
+            self.feeds_dir = self.station['rss']['dir']
+            self.feeds_enclosure = int(self.station['rss']['enclosure'])
+            if 'json' in self.station['rss']:
+                self.feeds_json = int(self.station['rss']['json'])
+            if 'rss' in self.station['rss']:
+                self.feeds_rss = int(self.station['rss']['rss'])
+            if 'playlist' in self.station['rss']:
+                self.feeds_playlist = int(self.station['rss']['playlist'])
 
-        if 'rss' in rss_options:
-            if 'mode' in rss_options['rss']:
-                self.rss_mode = int(rss_options['rss']['mode'])
-            else:
-                self.rss_mode = 0
-            self.rss_dir = rss_options['rss']['dir']
-            self.rss_enclosure = int(rss_options['rss']['enclosure'])
-            if 'json' in rss_options['rss']:
-                self.feed_json = int(rss_options['rss']['json'])
-            if 'rss' in rss_options['rss']:
-                self.feed_rss = int(rss_options['rss']['rss'])
+            self.feeds_media_url = self.channel.url + '/media/'
+            if 'media_url' in self.station['rss']:
+                if self.station['rss']['media_url']:
+                    self.feeds_media_url = self.station['rss']['media_url']
 
-            if 'media_url' in rss_options['rss']:
-                self.rss_media_url = rss_options['rss']['media_url']
-                if not self.rss_media_url:
-                    self.rss_media_url = self.channel.url + '/media/'
-
-        self.base_name = self.rss_dir + os.sep + self.short_name + '_' + self.channel.format
-        self.rss_current_file = self.base_name + '_current.xml'
-        self.rss_playlist_file = self.base_name + '_playlist.xml'
+        self.base_name = self.feeds_dir + os.sep + self.short_name + '_' + self.channel.format
+        self.feeds_current_file = self.base_name + '_current.xml'
+        self.feeds_playlist_file = self.base_name + '_playlist.xml'
 
         # Logging
         self.logger.write_info('Opening ' + self.short_name + ' - ' + self.channel.name + \
@@ -188,7 +186,7 @@ class Station(Thread):
 
         self.metadata_relative_dir = 'metadata'
         self.metadata_url = self.channel.url + '/rss/' + self.metadata_relative_dir
-        self.metadata_dir = self.rss_dir + os.sep + self.metadata_relative_dir
+        self.metadata_dir = self.feeds_dir + os.sep + self.metadata_relative_dir
         if not os.path.exists(self.metadata_dir):
             os.makedirs(self.metadata_dir)
 
@@ -292,7 +290,7 @@ class Station(Thread):
         message = "Station " + self.channel_url + \
                 " : received OSC message '%s' with arguments '%d'" % (path, value)
         self.m3u_url = self.channel.url + '/m3u/' + self.m3u.split(os.sep)[-1]
-        self.rss_url = self.channel.url + '/rss/' + self.rss_playlist_file.split(os.sep)[-1]
+        self.feeds_url = self.channel.url + '/rss/' + self.feeds_playlist_file.split(os.sep)[-1]
         self.logger.write_info(message)
 
     def jingles_callback(self, path, value):
@@ -396,7 +394,7 @@ class Station(Thread):
                     artist_tags = ' #'.join(list(set(artist_names)-set(['&', '-'])))
                     message = '#NEWTRACK ! %s #%s on #%s RSS: ' % \
                              (song.replace('_', ' '), artist_tags, self.short_name)
-                    message = message[:113] + self.rss_url
+                    message = message[:113] + self.feeds_url
                     self.update_twitter(message)
 
     def get_next_media(self):
@@ -418,6 +416,8 @@ class Station(Thread):
                 self.logger.write_info('Station ' + self.channel_url + \
                                  ' : generating new playlist (' + str(self.lp) + ' tracks)')
 
+                if self.feeds_playlist:
+                    self.update_feeds(self.media_to_objs(self.playlist), self.feeds_playlist_file, '(playlist)')
 
             elif lp_new != self.lp:
                 self.id = 0
@@ -445,9 +445,8 @@ class Station(Thread):
                 self.logger.write_info('Station ' + self.channel_url + \
                                  ' : generating new playlist (' + str(self.lp) + ' tracks)')
 
-                if self.rss_mode:
-                    self.update_rss(self.media_to_objs(self.playlist),
-                                self.rss_playlist_file, '(playlist)')
+                if self.feeds_playlist:
+                    self.update_feeds(self.media_to_objs(self.playlist), self.feeds_playlist_file, '(playlist)')
 
             if self.jingles_mode and not (self.counter % 2) and self.jingles_length:
                 media = self.jingles_list[self.jingle_id]
@@ -482,10 +481,13 @@ class Station(Thread):
                     continue
         return media_objs
 
-    def update_rss(self, media_list, rss_file, sub_title):
+    def update_feeds(self, media_list, rss_file, sub_title):
+        if not self.feeds_mode:
+            return
+            
         rss_item_list = []
-        if not os.path.exists(self.rss_dir):
-            os.makedirs(self.rss_dir)
+        if not os.path.exists(self.feeds_dir):
+            os.makedirs(self.feeds_dir)
         channel_subtitle = self.channel.name + ' ' + sub_title
         _date_now = datetime.datetime.now()
         date_now = str(_date_now)
@@ -519,8 +521,8 @@ class Station(Thread):
 
             media_absolute_playtime += media.length
 
-            if self.rss_enclosure == '1':
-                media_link = self.rss_media_url + media.file_name
+            if self.feeds_enclosure == '1':
+                media_link = self.feeds_media_url + media.file_name
                 media_link = media_link.decode('utf-8')
                 rss_item_list.append(RSSItem(
                     title = song,
@@ -551,15 +553,15 @@ class Station(Thread):
                             lastBuildDate = date_now,
                             items = rss_item_list,)
 
-        if self.feed_rss:
+        if self.feeds_rss:
             f = open(rss_file, 'w')
             rss.write_xml(f, 'utf-8')
             f.close()
 
-        if self.feed_json:
+        if self.feeds_json:
             path, fn = os.path.split(rss_file)
             base, ext = os.path.splitext(fn)
-            json_file = os.path.join(self.rss_dir, base + '.json')
+            json_file = os.path.join(self.feeds_dir, base + '.json')
             f = open(json_file, 'w')
             f.write(json.dumps(json_data, separators=(',',':')))
             f.close()
@@ -609,8 +611,7 @@ class Station(Thread):
         self.song = song.encode('utf-8')
         self.artist = self.artist.encode('utf-8')
         self.metadata_file = self.metadata_dir + os.sep + self.current_media_obj[0].file_name + '.xml'
-        if self.rss_mode:
-            self.update_rss(self.current_media_obj, self.rss_current_file, '(currently playing)')
+        self.update_feeds(self.current_media_obj, self.feeds_current_file, '(currently playing)')
         self.logger.write_info('DeeFuzzing on %s :  id = %s, name = %s' \
             % (self.short_name, self.id, self.current_media_obj[0].file_name))
         self.player.set_media(self.media)

--- a/example/deefuzzer.json
+++ b/example/deefuzzer.json
@@ -38,7 +38,11 @@
                 "mode": 0,
                 "url": "http://127.0.0.1:8000/telecaster_live.mp3"
             },
-            "rss": {
+            "feeds": {
+                "mode": 1,
+                "rss": 1,
+                "json": 0,
+                "playlist": 0,
                 "dir": "/path/to/rss",
                 "enclosure": 1,
                 "media_url": "http://localhost/media/"

--- a/example/deefuzzer.xml
+++ b/example/deefuzzer.xml
@@ -37,11 +37,15 @@
             <mode>0</mode>
             <url>http://127.0.0.1:8000/telecaster_live.mp3</url>
         </relay>
-        <rss>
+        <feeds>
+            <mode>1</mode>
+            <rss>1</rss>
+            <json>0</json>
+            <playlist>1</playlist>
             <dir>/path/to/rss/</dir>
             <enclosure>1</enclosure>
             <media_url>http://localhost/media/</media_url>
-        </rss>
+        </feeds>
         <server>
             <host>127.0.0.1</host>
             <mountpoint>monitor</mountpoint>

--- a/example/deefuzzer.yaml
+++ b/example/deefuzzer.yaml
@@ -32,7 +32,8 @@ deefuzzer:
             mode: 0,
             url: 'http://127.0.0.1:8000/telecaster_live.mp3'}
 
-    rss: {dir: /var/www/rss,
+    feeds: {mode: 1, rss: 1, json: 0, playlist: 1,
+          dir: /var/www/rss,
           enclosure: 0,
           media_url: 'http://localhost/media/'}
 

--- a/example/deefuzzer_doc.xml
+++ b/example/deefuzzer_doc.xml
@@ -68,19 +68,27 @@
             <!-- The URL of the station to relay -->
             <url>http://127.0.0.1:8000/telecaster_live.mp3</url>
         </relay>
-        <rss>
-            <!-- A path to the directory containing RSS (XML) files that is 'currently playing'
+        <feeds>
+            <!-- If '1', the feeds will output, '0' will do nothing.  Default: '1' -->
+            <mode>1</mode>
+            <!-- If '1', the feeds will output in RSS format, '0' will not.  Default: '1' -->
+            <rss>1</rss>
+            <!-- If '1', the feeds will output in JSON format, '0' will not.  Default: '0' -->
+            <json>0</json>
+            <!-- If '1', the feeds will output a 'playlist' feed, '0' will not.  Default: '1' -->
+            <playlist>1</playlist>
+            <!-- REQUIRED: A path to the directory containing RSS (XML) files that is 'currently playing'
                 and 'playlist' feeds (need write access rights to the directory).
                 The file is preferably accessible behind an url,
                 for example, http://mydomain.com/rss/mystation.xml -->
             <dir>/path/to/rss/</dir>
-            <!-- If '1', the RSS feeds will contain an enclosure to become a podcast feed.
+            <!-- REQUIRED: If '1', the RSS feeds will contain an enclosure to become a podcast feed.
                 '0' for simple RSS feed without enclosure -->
             <enclosure>1</enclosure>
-            <!-- the base URL of all media items (optional).
+            <!-- the base URL of all media items.
                  Default is station url /media -->
             <media_url>http://localhost/media/</media_url>
-        </rss>
+        </feeds>
         <server>
             <!-- The host to send the stream (domain or IP) -->
             <host>127.0.0.1</host>


### PR DESCRIPTION
Update of previous pull request to solve merge issues.

Reworked the RSS feed handling to allow JSON output as well, and added a lot of configuration options within the feed section. Also renamed the rss tag to feeds to better represent current reality (the rss tag is still used if the feeds tag is not present for backwards compatibility).
