### PR TITLE
Dev fixes

### DIFF
--- a/deefuzzer/core.py
+++ b/deefuzzer/core.py
@@ -123,10 +123,6 @@ class DeeFuzzer(Thread):
         for i in range(0,self.nb_stations):
             station = self.conf['deefuzzer']['station'][i]
 
-            # Apply station defaults if they exist
-            if 'stationdefaults' in self.conf['deefuzzer']:
-                if isinstance(self.conf['deefuzzer']['stationdefaults'], dict):
-                    station = merge_defaults(station, self.conf['deefuzzer']['stationdefaults'])
             self.stations.append(Station(station, q, self.logger, self.m3u))
 
         if self.m3u:


### PR DESCRIPTION
When the preferences object is created, a single station entry appears as an object instead of a list of objects with a single entry.  This causes multiple checks at various points based on the type of object.

This fix guarantees that the station list in the preferences will always be a list, even for one (or no) entries.

Signed-off-by: achbed github@achbed.org
