### PR TITLE
Logging tweaks, restart consistency fixes, media.source option

### DIFF
--- a/deefuzzer/core.py
+++ b/deefuzzer/core.py
@@ -285,6 +285,9 @@ class DeeFuzzer(Thread):
                             
                             if self.maxretry >= 0 and self.station_settings[i]['retries'] <= self.maxretry:
                                 # Station passed the max retries count is will not be reloaded
+                                if not 'station_stop_logged' in self.station_settings[i].keys():
+                                    self._err('Station ' + name + ' is stopped and will not be restarted.')
+                                    self.station_settings[i]['station_stop_logged'] = True
                                 continue
                                 
                             self.station_settings[i]['retries'] = self.station_settings[i]['retries'] + 1
@@ -302,18 +305,17 @@ class DeeFuzzer(Thread):
 
                     if name == '':
                         name = 'Station ' + str(i)
-                    
-                    if 'info' in self.station_settings[i].keys():
-                        if 'short_name' in self.station_settings[i]['infos']:
-                            name = self.station_settings[i]['infos']['short_name']
-                            y = 1
-                            while name in self.station_instances.keys():
-                                y = y + 1
-                                name = self.station_settings[i]['infos']['short_name'] + " " + str(y)
+                        if 'info' in self.station_settings[i].keys():
+                            if 'short_name' in self.station_settings[i]['infos']:
+                                name = self.station_settings[i]['infos']['short_name']
+                                y = 1
+                                while name in self.station_instances.keys():
+                                    y = y + 1
+                                    name = self.station_settings[i]['infos']['short_name'] + " " + str(y)
 
-                    self.station_settings[i]['station_name'] = name
-                    namehash = hashlib.md5(name).hexdigest()
-                    self.station_settings[i]['station_statusfile'] = os.sep.join([self.log_dir, namehash])
+                        self.station_settings[i]['station_name'] = name
+                        namehash = hashlib.md5(name).hexdigest()
+                        self.station_settings[i]['station_statusfile'] = os.sep.join([self.log_dir, namehash])
 
                     new_station = Station(self.station_settings[i], q, self.logqueue, self.m3u)
                     if new_station.valid:
@@ -323,7 +325,7 @@ class DeeFuzzer(Thread):
                     else:
                         self._err('Error validating station ' + name)
                 except Exception:
-                    self._err('Error creating station ' + name)
+                    self._err('Error initializing station ' + name)
                     if not ignoreErrors:
                         raise
                     continue

--- a/deefuzzer/core.py
+++ b/deefuzzer/core.py
@@ -204,7 +204,7 @@ class DeeFuzzer(Thread):
                 s[i] = replace_all(options[i], d)
         if not 'media' in s.keys():
             s['media'] = {}
-        s['media']['dir'] = folder
+        s['media']['source'] = folder
         self.add_station(s)
 
     def load_stations_fromconfig(self, folder):

--- a/example/deefuzzer.json
+++ b/example/deefuzzer.json
@@ -43,9 +43,8 @@
             },
             "media": {
                 "bitrate": 96,
-                "dir": "/path/to/mp3/",
+                "source": "/path/to/mp3/or/m3u",
                 "format": "mp3",
-                "m3u": "/path/to/m3u_file",
                 "ogg_quality": 4,
                 "samplerate": 48000,
                 "shuffle": 0,

--- a/example/deefuzzer.xml
+++ b/example/deefuzzer.xml
@@ -31,9 +31,8 @@
         </jingles>
         <media>
             <bitrate>96</bitrate>
-            <dir>/path/to/mp3/</dir>
+            <source>/path/to/mp3/or/m3u</source>
             <format>mp3</format>
-            <m3u>/path/to/m3u_file</m3u>
             <ogg_quality>4</ogg_quality>
             <samplerate>48000</samplerate>
             <shuffle>0</shuffle>

--- a/example/deefuzzer.yaml
+++ b/example/deefuzzer.yaml
@@ -25,9 +25,8 @@ deefuzzer:
               shuffle: 1}
 
     media: {bitrate: 96,
-            dir: /path/to/mp3/,
+            source: /path/to/mp3/or/m3u,
             format: mp3,
-            m3u: /path/to/m3u_file,
             ogg_quality: 4,
             samplerate: 48000,
             shuffle: 0,

--- a/example/deefuzzer_doc.xml
+++ b/example/deefuzzer_doc.xml
@@ -63,7 +63,8 @@
             <!-- A path to the directory containing jingles media files.
                 The files have to be of the same type of the main media files. -->
             <dir>/path/to/jingles</dir>
-            <!-- If '1', some media will be played between each main track of the playlist. '0' does nothing. -->
+            <!-- If '1', some media will be played between each main track of the 
+                playlist. '0' does nothing. -->
             <mode>0</mode>
             <!-- If '1', the jingle playlist will be randomized. '0' for alphanumeric order -->
             <shuffle>1</shuffle>
@@ -71,12 +72,17 @@
         <media>
             <!-- The mean bitrate of the media -->
             <bitrate>96</bitrate>
-            <!-- The path to the directory containing all the media. It will be analyzed recursively. -->
-            <dir>/path/to/mp3/</dir>
+            <!-- The <m3u> option is depreciated.  Please use the newer <source> option. -->
+            <m3u>/path/to/m3u_file</m3u>
+            <!-- The <dir> option is depreciated.  Please use the newer <source> option.
+                  This option overrides the <m3u> option if both are specified. -->
+            <dir>/path/to/mp3_folder</dir>
+            <!-- The path to the folder containing audio files, or the M3U playlist file to
+                  use as source audio for this  station.  This option overrides both the <dir>
+                  and <m3u> depreciated options if they are specified. -->
+            <source>/path/to/m3u_file_or_folder</source>
             <!-- The audio format of the media. Can be 'mp3' or 'ogg' -->
             <format>mp3</format>
-            <!-- You can also give a M3U playlist file -->
-            <m3u>/path/to/m3u_file</m3u>
             <!-- The ogg quality of the ogg vorbis media -->
             <ogg_quality>4</ogg_quality>
             <!-- The sample rate of the media -->

--- a/example/stationconfig_doc.xml
+++ b/example/stationconfig_doc.xml
@@ -16,9 +16,8 @@
     </jingles>
     <media>
         <bitrate>96</bitrate>
-        <dir>/path/to/mp3/</dir>
+        <source>/path/to/mp3/or/m3u</source>
         <format>mp3</format>
-        <m3u>/path/to/m3u_file</m3u>
         <ogg_quality>4</ogg_quality>
         <samplerate>48000</samplerate>
         <shuffle>0</shuffle>


### PR DESCRIPTION
Additional logging when a station was found stopped and will never be restarted
Better description in logging station initialization errors
Internal station name and status filenames will no longer be regenerated on automatic station restart