### PR TITLE
Remove brocken link in doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,6 @@ Documentation
  * Configuration examples:
      
      * `Dummy XML for testing <https://github.com/yomguy/DeeFuzzer/blob/master/example/deefuzzer.xml>`_
-     * `OGG Vorbis and MP3 together <https://github.com/yomguy/DeeFuzzer/blob/master/example/deefuzzer_mp3_ogg.xml>`_
      * `Generic YAML <https://github.com/yomguy/DeeFuzzer/blob/master/example/deefuzzer.yaml>`_
 
 


### PR DESCRIPTION
Remove brocken link: "OGG Vorbis and MP3 together"
@yomguy same error in `dev` and `release\0.7` branch.