### PR TITLE
Support for MySQLdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,11 @@ Because our aim is to get DeeFuzzer as light as possible it is NOT capable of re
 News
 ====
 
+0.7.1
+
+ * Bugfix release
+ * Fix no metadata for stream-m relaying
+
 0.7
 
  * **Huge** refactoring which should be compatible with old setups, but before updating **please read** the `updated example <https://github.com/yomguy/DeeFuzzer/blob/dev/example/deefuzzer_doc.xml>`_ and the following news.

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Features
  * Very light and optimized streaming process
  * Fully written in Python
  * Works with Icecast2, ShoutCast, Stream-m
+ * (NEW) Works with MySQL playlists
 
 Because our aim is to get DeeFuzzer as light as possible it is NOT capable of re-encoding or transcoding media files for the moment.
 

--- a/deefuzzer/station.py
+++ b/deefuzzer/station.py
@@ -440,11 +440,17 @@ class Station(Thread):
                                       port = self.mdb_port,
                                       use_unicode = True)
                     cur = con.cursor()
-                    cur.execute("SELECT %s FROM %s".format(self.mdb_field, self.mdb_table))
-                    file_list = cur.fetchall()
+                    cur.execute("SELECT %s FROM %s" % (self.mdb_field, self.mdb_table))
+                    rows = cur.fetchall()
+                    for row in rows:
+                        file_list.append(row[0])
 
                 except mdb.Error, e:
                     self._err('Could not get playlist from MySQLdb, Error %d: %s' % (e.args[0], e.args[1]))
+
+                finally:
+                    if con:
+                        con.close()
 
             # Directory
             elif os.path.isdir(self.media_source):

--- a/deefuzzer/station.py
+++ b/deefuzzer/station.py
@@ -46,6 +46,7 @@ import shout
 import urllib
 import mimetypes
 import json
+import MySQLdb as mdb
 
 from threading import Thread
 from player import *
@@ -87,6 +88,13 @@ class Station(Thread):
     jingles_frequency = 2
     statusfile = ''
     base_directory = ''
+    mdb_host = '127.0.0.1'
+    mdb_port = 3306
+    mdb_user = ''
+    mdb_password = ''
+    mdb_database = ''
+    mdb_table = ''
+    mdb_field = ''
 
     def __init__(self, station, q, logqueue, m3u):
         Thread.__init__(self)
@@ -123,6 +131,23 @@ class Station(Thread):
             if not self.station['media']['source'].strip() == '':
                 self.media_source = self._path_add_base(self.station['media']['source'])
 
+        # MySQL
+        if 'mysql' in self.station['media']:
+            if 'host' in self.station['media']['mysql']:
+                self.mdb_host = self.station['media']['mysql']['host']
+            if 'port' in self.station['media']['mysql']:
+                self.mdb_port = self.station['media']['mysql']['port']
+            if 'user' in self.station['media']['mysql']:
+                self.mdb_user = self.station['media']['mysql']['user']
+            if 'password' in self.station['media']['mysql']:
+                self.mdb_password = self.station['media']['mysql']['password']
+            if 'database' in self.station['media']['mysql']:
+                self.mdb_database = self.station['media']['mysql']['database']
+            if 'table' in self.station['media']['mysql']:
+                self.mdb_table = self.station['media']['mysql']['table']
+            if 'field' in self.station['media']['mysql']:
+                self.mdb_field = self.station['media']['mysql']['field']
+
         self.media_format = self.station['media']['format']
         self.shuffle_mode = int(self.station['media']['shuffle'])
         self.bitrate = int(self.station['media']['bitrate'])
@@ -150,25 +175,26 @@ class Station(Thread):
 
         if 'stream-m' in self.type:
             self.channel = HTTPStreamer()
-            self.channel.mount = '/publish/' + self.mountpoint
+            self.channel.mount = '/publish/' + str(self.mountpoint)
         elif 'icecast' in self.type:
             self.channel = shout.Shout()
-            self.channel.mount = '/' + self.mountpoint
+            self.channel.mount = '/' + str(self.mountpoint)
             if self.appendtype:
-                self.channel.mount = self.channel.mount + '.' + self.media_format
+                self.channel.mount = str(self.channel.mount) + '.' + str(self.media_format)
         else:
             self._err('Not a compatible server type. Choose "stream-m" or "icecast".')
             return
 
-        self.channel.url = self.station['infos']['url']
-        self.channel.name = self.station['infos']['name']
-        self.channel.genre = self.station['infos']['genre']
-        self.channel.description = self.station['infos']['description']
-        self.channel.format = self.media_format
-        self.channel.host = self.station['server']['host']
+        # Shout requires non-unicode strings
+        self.channel.url = str(self.station['infos']['url'])
+        self.channel.name = str(self.station['infos']['name'])
+        self.channel.genre = str(self.station['infos']['genre'])
+        self.channel.description = str(self.station['infos']['description'])
+        self.channel.format = str(self.media_format)
+        self.channel.host = str(self.station['server']['host'])
         self.channel.port = int(self.station['server']['port'])
         self.channel.user = 'source'
-        self.channel.password = self.station['server']['sourcepassword']
+        self.channel.password = str(self.station['server']['sourcepassword'])
         self.channel.public = int(self.station['server']['public'])
         if self.channel.format == 'mp3':
             self.channel.audio_info = {'bitrate': str(self.bitrate),
@@ -180,7 +206,7 @@ class Station(Thread):
                                        'quality': str(self.ogg_quality),
                                        'channels': str(self.voices), }
 
-        self.server_url = 'http://' + self.channel.host + ':' + str(self.channel.port)
+        self.server_url = 'http://' + str(self.channel.host) + ':' + str(self.channel.port)
         self.channel_url = self.server_url + self.channel.mount
 
         # RSS
@@ -404,7 +430,24 @@ class Station(Thread):
         file_list = []
 
         try:
-            if os.path.isdir(self.media_source):
+            # MySQLdb
+            if 'mysql' in self.station['media']:
+                try:
+                    con = mdb.connect(host = self.mdb_host,
+                                      user = self.mdb_user,
+                                      passwd = self.mdb_password,
+                                      db = self.mdb_database,
+                                      port = self.mdb_port,
+                                      use_unicode = True)
+                    cur = con.cursor()
+                    cur.execute("SELECT %s FROM %s".format(self.mdb_field, self.mdb_table))
+                    file_list = cur.fetchall()
+
+                except mdb.Error, e:
+                    self._err('Could not get playlist from MySQLdb, Error %d: %s' % (e.args[0], e.args[1]))
+
+            # Directory
+            elif os.path.isdir(self.media_source):
                 self.q.get(1)
                 try:
                     for root, dirs, files in os.walk(self.media_source):
@@ -418,7 +461,8 @@ class Station(Thread):
                     pass
                 self.q.task_done()
 
-            if os.path.isfile(self.media_source):
+            # File
+            elif os.path.isfile(self.media_source):
                 self.q.get(1)
                 try:
                     f = open(self.media_source, 'r')
@@ -895,4 +939,3 @@ class Station(Thread):
 
                 self.channel_close()
                 time.sleep(1)
-

--- a/example/deefuzzer.json
+++ b/example/deefuzzer.json
@@ -85,30 +85,34 @@
             }
         },
         "station": {
-          "infos": {
-              "description": "MySQL funky playlist",
-              "genre": "Various Funk Groove",
-              "name": "My best funky station",
-              "short_name": "My_station2",
-              "url": "http://parisson.com"
-          },
-          "media": {
-              "bitrate": 96,
-              "format": "mp3",
-              "ogg_quality": 4,
-              "samplerate": 48000,
-              "shuffle": 0,
-              "voices": 2,
-      				"mysql": {
-                "host": "127.0.0.1",
-                "port": 3306,
-      					"user": "username",
-      					"password": "password",
-      					"database": "deefuzze_database",
-      					"table": "deefuzze_playlist",
-      					"field": "mp3"
-      				}
-          }
+            "control": {
+                "mode": 0,
+                "port": 16001
+            },
+            "infos": {
+                "description": "MySQL funky playlist",
+                "genre": "Various Funk Groove",
+                "name": "My best funky station managed with MySQL",
+                "short_name": "MySQL_station",
+                "url": "http://parisson.com"
+            },
+            "media": {
+                "bitrate": 96,
+                "format": "mp3",
+                "ogg_quality": 4,
+                "samplerate": 48000,
+                "shuffle": 0,
+                "voices": 2,
+                "mysql": {
+                    "host": "127.0.0.1",
+                    "port": 3306,
+                    "user": "username",
+                    "password": "password",
+                    "database": "database_name",
+                    "table": "playlist_table",
+                    "field": "absolute_path"
+				}
+            }
         }
     }
 }

--- a/example/deefuzzer.json
+++ b/example/deefuzzer.json
@@ -48,7 +48,7 @@
                 "ogg_quality": 4,
                 "samplerate": 48000,
                 "shuffle": 0,
-                "voices": "2"
+                "voices": 2
             },
             "record": {
                 "dir": "/path/to/archives",
@@ -83,6 +83,32 @@
                 "secret": "your access token secret key",
                 "tags": "parisson deefuzzer"
             }
+        },
+        "station": {
+          "infos": {
+              "description": "MySQL funky playlist",
+              "genre": "Various Funk Groove",
+              "name": "My best funky station",
+              "short_name": "My_station2",
+              "url": "http://parisson.com"
+          },
+          "media": {
+              "bitrate": 96,
+              "format": "mp3",
+              "ogg_quality": 4,
+              "samplerate": 48000,
+              "shuffle": 0,
+              "voices": 2,
+      				"mysql": {
+                "host": "127.0.0.1",
+                "port": 3306,
+      					"user": "username",
+      					"password": "password",
+      					"database": "deefuzze_database",
+      					"table": "deefuzze_playlist",
+      					"field": "mp3"
+      				}
+          }
         }
     }
 }

--- a/example/deefuzzer.json
+++ b/example/deefuzzer.json
@@ -111,7 +111,7 @@
                     "database": "database_name",
                     "table": "playlist_table",
                     "field": "absolute_path"
-				}
+                }
             }
         }
     }

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description=open('README.rst').read(),
     author="Guillaume Pellerin",
     author_email="yomguy@parisson.com",
-    version='0.7.1',
+    version='0.7.2',
     install_requires=[
         'setuptools',
         'python-shout',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'mutagen',
         'pyliblo',
         'pycurl',
-        'pyyaml'
+        'pyyaml',
+        'mysql'
     ],
     platforms=['OS Independent'],
     license='CeCILL v2',


### PR DESCRIPTION
Hi! I'm the dev of http://radiopiranha.com and we found your solution very nice and easy to suit to our needs and I thought maybe you would be interested in having this little feature...

Basically, instead of providing a "source" in the "media" of the config file, the user can put a "mysql" entry with his login infos and tells Deefuzzer which field of which table to look for while making the playlist.

If you need more specifications in the docs just tell me, I'll do it.

Also, I noted that you cannot have stations without defining a "feeds" or "rss".... (see __init__ of station.py line 237)... is it normal? We absolutely need to set a path for the feeds, even if we don't use any? If its a bad side effect I can try to fix it too...