### PR TITLE
MySQL songs requests

### DIFF
--- a/deefuzzer/station.py
+++ b/deefuzzer/station.py
@@ -514,7 +514,7 @@ class Station(Thread):
                     break
 
             except mdb.Error as e:
-                self._err('Could not get playlist from MySQLdb, Error %d: %s' % (e.args[0], e.args[1]))
+                self._err('Could not get requests from MySQLdb, Error %d: %s' % (e.args[0], e.args[1]))
 
             finally:
                 if con:

--- a/deefuzzer/station.py
+++ b/deefuzzer/station.py
@@ -82,7 +82,7 @@ class Station(Thread):
     mdb_table = ''
     mdb_field = ''
     mdb_request_table = ''
-    mdb_request_field ''
+    mdb_request_field = ''
     mdb_request_played = ''
     feeds_dir = ''
     is_alive = False

--- a/deefuzzer/station.py
+++ b/deefuzzer/station.py
@@ -554,9 +554,6 @@ class Station(Thread):
         if self.lp:
             playlist = self.playlist
             new_playlist = self.get_playlist()
-            requested_media = self.get_request()
-            if requested_media:
-                self._info('Requested media: ' + requested_media)
             lp_new = len(new_playlist)
 
             if not self.counter:
@@ -603,15 +600,19 @@ class Station(Thread):
 
                 self._info('Generating new playlist (' + str(self.lp) + ' tracks)')
 
+
             if self.jingles_mode and not (self.counter % self.jingles_frequency) and self.jingles_length:
                 media = self.jingles_list[self.jingle_id]
                 self.jingle_id = (self.jingle_id + 1) % self.jingles_length
-            elif requested_media:
-                media = requested_media
-                self.id = (self.playlist.index(requested_media) + 1) % self.lp
             else:
-                media = self.playlist[self.id]
-                self.id = (self.id + 1) % self.lp
+                requested_media = self.get_request()
+                if requested_media:
+                    self._info('Requested media: ' + requested_media)
+                    media = requested_media
+                    self.id = (self.playlist.index(requested_media) + 1) % self.lp
+                else:
+                    media = self.playlist[self.id]
+                    self.id = (self.id + 1) % self.lp
 
             self.q.get(1)
             try:

--- a/example/deefuzzer.json
+++ b/example/deefuzzer.json
@@ -110,7 +110,10 @@
                     "password": "password",
                     "database": "database_name",
                     "table": "playlist_table",
-                    "field": "absolute_path"
+                    "field": "absolute_path",
+                    "request_table": "request_table",
+                    "request_field": "absolute_path",
+                    "request_played": "played_bool_field"
                 }
             }
         }


### PR DESCRIPTION
I added this feature to my website: https://radiodoom.ca and its working fine!
Thought some people would enjoy this feature too, basically you add the settings, for eg : 
```
...
           "media": {
                "bitrate": 128,
                "source": "/var/www/music",
                "mysql": {
                    "host": "127.0.0.1",
                    "port": 3306,
                    "user": "user",
                    "password": "password",
                    "database": "database_name",
                    "table": "radio_playlist_vaporfunk",
                    "field": "path",
                    "request_table": "radio_request_vaporfunk",
                    "request_field": "path",
                    "request_played": "played"
                },
...
```

When a new request is added in the database, it will be played and marked as `played` on the next song.